### PR TITLE
Point the 'globs' dependency to NPM instead of github

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/stephenmathieson/node-concatenate.git"
   },
   "dependencies": {
-    "globs": "git://github.com/stephenmathieson/node-globs.git#master"
+    "globs": "^0.1.2"
   },
   "devDependencies": {
     "mocha": "latest",


### PR DESCRIPTION
Pointing to a `git://` url results in an error if you're on a restricted network (https://github.com/JeffreyWay/laravel-mix/issues/85)

If you really need it to point to github, you could use the short format: https://docs.npmjs.com/files/package.json#github-urls